### PR TITLE
run iframecleanup before starting new callback loop

### DIFF
--- a/src/react-valence-ui-iframe.js
+++ b/src/react-valence-ui-iframe.js
@@ -36,11 +36,18 @@ var ResizingIframe = React.createClass({
 		this.updateProgress(100);
 
 		if (this.props.resizeCallback) {
+			if (this.state.iframeCleanup) {
+				this.state.iframeCleanup();
+			}
 			var result = ResizeCallbackMaker.startResizingCallbacks(React.findDOMNode(this.refs.iframe), this.callbackWrapper);
 
 			if (result.cleanup) {
 				this.setState({
 					iframeCleanup: result.cleanup
+				});
+			} else {
+				this.setState({
+					iframeCleanup: null
 				});
 			}
 		}


### PR DESCRIPTION
[DE22219: [Christian's UI Review] Scroll Issues on D2L Tools](https://rally1.rallydev.com/#/42651186647d/detail/defect/59129874131)

When interacting within the d2l tool's UI the iframe housing it will often re-load. This causes the iframe resize logic to start up a new callback resize listener, but not cleanup the previous one. This PR fixes that.