### PR TITLE
Fix cleanup error

### DIFF
--- a/src/ResizeCallbackMaker.js
+++ b/src/ResizeCallbackMaker.js
@@ -115,6 +115,11 @@ ResizeCallbackMaker.prototype.startResizingCallbacks = function(iframe, callback
 	// ios has problems with scrolling when tapping inside an iframe, so we won't try to size them bigger than the screen
 	if (this.isIos(navigator)) {
 		callback(null, null);
+
+		return {
+			security: 'crossDomain',
+			cleanup: null
+		};
 	} else if (this.crossDomain(iframe)) {
 		// The content is on another domain. If it includes /d2l/common/iframe/iframe-client.js, it can tell us its height
 		var self = this;

--- a/src/__tests__/react-valence-ui-iframe.js
+++ b/src/__tests__/react-valence-ui-iframe.js
@@ -57,6 +57,16 @@ describe('react-valence-ui-iframe', function() {
 		expect(resizeCallbackMakerStub.called).toBe(true);
 	});
 
+	it('should not throw an error if the ResizeCallbackMaker startResizingCallbacks does not return a result', function() {
+		ReactIframe.__Rewire__('ResizeCallbackMaker', { startResizingCallbacks: sinon.stub(), crossDomain: crossDomainStub });
+		var callback = sinon.stub();
+		var elem = TestUtils.renderIntoDocument(<ReactIframe resizeCallback={callback}/>);
+		elem.handleOnLoad();
+
+		expect(elem.state.iframeCleanup).toBe(null);
+	});
+
+
 	it('should set the "cleanup" state to the variable returned by the resizeCallbackMaker', function() {
 		ReactIframe.__Rewire__('ResizeCallbackMaker', { startResizingCallbacks: resizeCallbackMakerStub, crossDomain: crossDomainStub });
 		var callback = sinon.stub();

--- a/src/__tests__/react-valence-ui-iframe.js
+++ b/src/__tests__/react-valence-ui-iframe.js
@@ -66,7 +66,6 @@ describe('react-valence-ui-iframe', function() {
 		expect(elem.state.iframeCleanup).toBe(null);
 	});
 
-
 	it('should set the "cleanup" state to the variable returned by the resizeCallbackMaker', function() {
 		ReactIframe.__Rewire__('ResizeCallbackMaker', { startResizingCallbacks: resizeCallbackMakerStub, crossDomain: crossDomainStub });
 		var callback = sinon.stub();

--- a/src/__tests__/resizeCallbackMaker.js
+++ b/src/__tests__/resizeCallbackMaker.js
@@ -35,11 +35,23 @@ describe('react-valence-ui-iframe', function() {
 			).toThrow('no callback provided');
 		});
 
-		it('should call the callback with null,null if the platform is ios', function() {
-			sandbox.stub(ResizeCallbackMaker, 'isIos').returns(true);
+		describe('isIos', function() {
+			beforeEach(function() {
+				sandbox.stub(ResizeCallbackMaker, 'isIos').returns(true);
+			});
 
-			ResizeCallbackMaker.startResizingCallbacks(iframe, callback);
-			expect(callback.calledWith(null, null)).toBe(true);
+			it('should call the callback with null, null', function() {
+				ResizeCallbackMaker.startResizingCallbacks(iframe, callback);
+				expect(callback.calledWith(null, null)).toBe(true);
+			});
+
+			it('should return the proper values', function() {
+				sandbox.stub(ResizeCallbackMaker, 'requestIframeSize');
+
+				var returnVal = ResizeCallbackMaker.startResizingCallbacks(iframe, callback);
+				expect(returnVal.security).toBe('crossDomain');
+				expect(returnVal.cleanup === null).toBe(true);
+			});
 		});
 
 		describe('crossDomain', function() {

--- a/src/react-valence-ui-iframe.js
+++ b/src/react-valence-ui-iframe.js
@@ -41,7 +41,7 @@ var ResizingIframe = React.createClass({
 			}
 			var result = ResizeCallbackMaker.startResizingCallbacks(React.findDOMNode(this.refs.iframe), this.callbackWrapper);
 
-			if (result.cleanup) {
+			if (result && result.cleanup) {
 				this.setState({
 					iframeCleanup: result.cleanup
 				});


### PR DESCRIPTION
Should fix [DE22438](https://rally1.rallydev.com/#/42651186647d/detail/defect/60573852803)

Basic idea is that on iOS devices the startResizingCallbacks method was not returning an object, so the javascript would fail and leave the iframe size in an incorrect state, resulting in scrolling not working properly. This fixes the javascript error which should result in the scrolling working as desired.
