### PR TITLE
move to the new method of suppressing d2l-navigation element

### DIFF
--- a/src/__tests__/react-valence-ui-iframe.js
+++ b/src/__tests__/react-valence-ui-iframe.js
@@ -139,25 +139,15 @@ describe('react-valence-ui-iframe', function() {
 		expect(React.findDOMNode(wrapper).style['overflow-y']).toBe(iframeOverflowY);
 	});
 
-	it('should render a d2l_navbar element offscreen', function() {
+	it('should render a d2l-suppress-nav element offscreen', function() {
 		var elem = TestUtils.renderIntoDocument(
 			<ReactIframe />
 		);
 		var wrapper = TestUtils.scryRenderedDOMComponentsWithClass(
 			elem,
-			'vui-offscreen'
+			'vui-offscreen d2l-suppress-nav'
 		);
 
 		expect(wrapper.length).toBe(1);
-		expect(React.findDOMNode(wrapper[0]).id).toBe('d2l_navbar');
-	});
-
-	it('should render a d2l-navigation element', function() {
-		var elem = TestUtils.renderIntoDocument(
-			<ReactIframe />
-		);
-
-		// scryRenderedDOMComponentsWithTag wouldn't pick up the dangerouslySetInnerHTML inserted polymer component
-		expect(React.findDOMNode(elem).innerHTML.indexOf('<d2l-navigation ')).toBeGreaterThan(-1);
 	});
 });

--- a/src/react-valence-ui-iframe.js
+++ b/src/react-valence-ui-iframe.js
@@ -67,7 +67,7 @@ var ResizingIframe = React.createClass({
 			<div
 				className="resizing-iframe-container"
 			>
-				<div id="d2l_navbar" className="vui-offscreen" dangerouslySetInnerHTML={{__html: '<d2l-navigation duplicate="true"></d2l-navigation>'}}></div>
+				<div className="vui-offscreen d2l-suppress-nav"></div>
 				<iframe
 					ref="iframe"
 					onLoad={this.handleOnLoad}


### PR DESCRIPTION
https://github.com/Brightspace/d2l-navigation-ui/pull/199/files introduces a new method for suppressing d2l-navigation elements beyond just relying on the isDuplicate logic, which no longer detected hidden parent d2l-navigation elements. This PR makes use of the new method.