### PR TITLE
DE23815

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-valence-ui-iframe",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "An iframe wrapper which provides callbacks for when the iframe has loaded and callbacks providing the size of the iframe's contents if we can figure them out",
   "main": "src/react-valence-ui-iframe.js",
   "scripts": {

--- a/src/react-valence-ui-iframe.js
+++ b/src/react-valence-ui-iframe.js
@@ -74,6 +74,7 @@ var ResizingIframe = React.createClass({
 					src={this.props.src}
 					style={style}
 					className="resizing-iframe"
+					allowfullscreen
 				>
 				</iframe>
 			</div>

--- a/src/react-valence-ui-iframe.js
+++ b/src/react-valence-ui-iframe.js
@@ -74,7 +74,7 @@ var ResizingIframe = React.createClass({
 					src={this.props.src}
 					style={style}
 					className="resizing-iframe"
-					allowfullscreen
+					allowFullScreen
 				>
 				</iframe>
 			</div>


### PR DESCRIPTION
Set allowFullScreen on the iframe for ASV. This allows embeds, such as youtube iframes to go full screen.