### PR TITLE
DE39880 - Adding fullscreen to the Allow list

### DIFF
--- a/src/d2l-iframe-wrapper-for-react.js
+++ b/src/d2l-iframe-wrapper-for-react.js
@@ -62,7 +62,7 @@ class IFrame extends LitElement {
 			<iframe
 				class="resizing-iframe"
 				src=${this.src}
-				allow="camera *; microphone *; display-capture *; encrypted-media *;"
+				allow="camera *; microphone *; display-capture *; encrypted-media *; fullscreen *;"
 				@load=${this._onFrameLoad}}
 				style=${styleMap(style)}
 			></iframe>


### PR DESCRIPTION
Trying to add in the deprecated allowfullscreen attribute to the iframe no longer works when the iframe is inside a lit element. This approach is better anyways