### PR TITLE
Don't repeatedly resize if rendering an Lessons file

### DIFF
--- a/src/ResizeCallbackMaker.js
+++ b/src/ResizeCallbackMaker.js
@@ -134,8 +134,13 @@ ResizeCallbackMaker.prototype.startResizingCallbacks = function(iframe, callback
 			cleanup: stopListening
 		};
 	} else {
+		// Hack to prevent the callback from being repeatedly called when rendering a file in Lessons.
+		// This was causing height & overflow-y to be incorrect as a recent
+		// change caused these to now be on the same domain.
+		const iframeIsLessonsFile = iframe && iframe.classList.contains('html-topic-iframe');
+
 		var props = {
-			toggle: true,
+			toggle: !iframeIsLessonsFile,
 			callback: callback,
 			iframe: iframe
 		};


### PR DESCRIPTION
A recent change to Lessons is causing html/pdf files to now be on the same origin as Lessons/LMS. This code path will attempt to repeatedly resize, and add `overflow-y: hidden` to the iframe body. This is bit of a hack to prevent that from happening. When rendering these types of files, it won't repeatedly resize itself.

I won't know this for sure works yet until it's merged, without getting into too much detail I can't actually test this all locally, as once I start to debug locally my lessons now has a different domain than my lms as it's running at `localhost:3000`.