### PR TITLE
PHNX-1945: Remove extra curly brace

### DIFF
--- a/src/d2l-iframe-wrapper-for-react.js
+++ b/src/d2l-iframe-wrapper-for-react.js
@@ -63,7 +63,7 @@ class IFrame extends LitElement {
 				class="resizing-iframe"
 				src=${this.src}
 				allow="camera *; microphone *; display-capture *; encrypted-media *; fullscreen *; autoplay *;"
-				@load=${this._onFrameLoad}}
+				@load=${this._onFrameLoad}
 				style=${styleMap(style)}
 			></iframe>
 		`;


### PR DESCRIPTION
## Jira Ticket
[PHNX-1945](https://desire2learn.atlassian.net/jira/software/c/projects/PHNX/boards/341?selectedIssue=PHNX-1945): 20.24.7 > LOR topics not displaying in lessons

## Description
After the upgrade to Lit 3, some topics in Lessons weren't being displayed. This is because the loading spinner wasn't being cleared once the topic was loaded.

This is due to an extra curly brace on the `@load` event binding - something probably changed between lit2 and lit3, although I'm surprised it was working to begin with!  This PR removes the extra curly brace.

[PHNX-1945]: https://desire2learn.atlassian.net/browse/PHNX-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ